### PR TITLE
Keeping the original schema around, so we can keep access to the actual DB definition

### DIFF
--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -19,6 +19,7 @@ type invertedSchema[T comparable] map[T]struct {
 // for metric names, allowing the use of custom types as long as they are
 // comparable.
 type TSSchema[T comparable] struct {
+	Schema         Schema[T]
 	invertedSchema invertedSchema[T]
 }
 
@@ -26,7 +27,7 @@ type TSSchema[T comparable] struct {
 // The schema parameter is a mapping from table names to measure names and
 // then to metric names of the generic type T.
 func NewTSSchema[T comparable](schema Schema[T]) TSSchema[T] {
-	return TSSchema[T]{invertedSchema: invertSchema(schema)}
+	return TSSchema[T]{Schema: schema, invertedSchema: invertSchema(schema)}
 }
 
 func invertSchema[T comparable](schema Schema[T]) invertedSchema[T] {


### PR DESCRIPTION
## What?
Keeping the original schema once the schema has been instantiated

## Why?

So clients can still have access to the actual definition. This can be useful for parsing information after the fact.