### PR TITLE
Avoid double definition of MeasureValueType

### DIFF
--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -99,9 +99,8 @@ func (t TSSchema[T1, T2]) GenerateDummyData(db string, time time.Time, predefine
 
 		for measureName, metricNames := range measures {
 			record := types.Record{
-				MeasureName:      aws.String(fmt.Sprintf("%v", measureName)), // Convert measure name to *string
-				MeasureValueType: types.MeasureValueTypeMulti,
-				Time:             aws.String(fmt.Sprintf("%d", time.UnixMilli())),
+				MeasureName: aws.String(fmt.Sprintf("%v", measureName)), // Convert measure name to *string
+				Time:        aws.String(fmt.Sprintf("%d", time.UnixMilli())),
 			}
 			measureValues := make([]types.MeasureValue, 0, len(metricNames.MetricNames))
 			for _, metricName := range metricNames.MetricNames {

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -223,8 +223,7 @@ func TestTSSchema_GenerateDummyData(t1 *testing.T) {
 									Value: aws.String("dummy"),
 								},
 							},
-							MeasureName:      aws.String("measure_1"),
-							MeasureValueType: types.MeasureValueTypeMulti,
+							MeasureName: aws.String("measure_1"),
 							MeasureValues: []types.MeasureValue{
 								{
 									Name:  aws.String("metric_1"),
@@ -260,8 +259,7 @@ func TestTSSchema_GenerateDummyData(t1 *testing.T) {
 									Value: aws.String("dummy"),
 								},
 							},
-							MeasureName:      aws.String("measure_2"),
-							MeasureValueType: types.MeasureValueTypeMulti,
+							MeasureName: aws.String("measure_2"),
 							MeasureValues: []types.MeasureValue{
 								{
 									Name:  aws.String("metric_3"),
@@ -283,8 +281,7 @@ func TestTSSchema_GenerateDummyData(t1 *testing.T) {
 									Value: aws.String("dummy"),
 								},
 							},
-							MeasureName:      aws.String("measure_3"),
-							MeasureValueType: types.MeasureValueTypeMulti,
+							MeasureName: aws.String("measure_3"),
 							MeasureValues: []types.MeasureValue{
 								{
 									Name:  aws.String("metric_5"),


### PR DESCRIPTION
Avoid double definition of MeasureValueType, as this is considered an error in Timestream.

The value is now defined only in the common attributes