### PR TITLE
Adding support to time units for Marshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ TimeSchema is a Go library tailored for interacting with AWS Timestream, offerin
 
 ## Features
 - **Data Marshalling**: Convert Go structs to AWS Timestream records with ease, using struct tags for precise field mapping.
+- Supports specifying time units (seconds, milliseconds, nanoseconds) for `time.Time` fields in structs.
 - **Data Unmarshalling**: Seamlessly decode AWS Timestream query outputs into Go structs or slices of structs.
 - **Query Building**: Dynamically construct SQL queries for Timestream with named placeholders and a variety of data types.
 - **Schema Management**: Utilize generic types for flexible and efficient schema definitions in AWS Timestream.
@@ -30,6 +31,7 @@ type MyData struct {
     SensorName   string    `timestream:"measure"`
     Location     string    `timestream:"dimension,name=location"`
     Temperature  float64   `timestream:"attribute,name=temperature"`
+    EventTime    time.Time `timestream:"attribute,name=eventTime,unit=ms"`
 }
 
 func main() {
@@ -38,6 +40,7 @@ func main() {
         SensorName:   "Sensor1",
         Location:     "Room1",
         Temperature:  23.5,
+        EventTime:    time.Now(),
     }
 
     record, err := timeschema.Marshal(data)

--- a/pkg/marshal.go
+++ b/pkg/marshal.go
@@ -164,24 +164,20 @@ func handleRecord(record *types.Record, val reflect.Value, i int, tag string) er
 		dimensionName := val.Field(i).Interface().(string)
 		record.Dimensions = append(record.Dimensions, types.Dimension{Name: &tagName, Value: aws.String(dimensionName)})
 	case attribute:
-		measureValue, err := handleMeasureValue(tagName, tag, val.Field(i), omitempty)
+		if omitempty && isZeroValue(val.Field(i)) {
+			return nil
+		}
+		measureValue, err := handleMeasureValue(tagName, tag, val.Field(i))
 		if err != nil {
 			return err
 		}
-		if !reflect.DeepEqual(measureValue, types.MeasureValue{}) {
-			record.MeasureValues = append(record.MeasureValues, measureValue)
-		}
+		record.MeasureValues = append(record.MeasureValues, measureValue)
 	}
 	return nil
 }
 
-func handleMeasureValue(tagName, tag string, fieldValue reflect.Value, omitEmpty bool) (types.MeasureValue, error) {
+func handleMeasureValue(tagName, tag string, fieldValue reflect.Value) (types.MeasureValue, error) {
 	var measureValue types.MeasureValue
-
-	// Check for zero value and omitEmpty
-	if omitEmpty && isZeroValue(fieldValue) {
-		return types.MeasureValue{}, nil // Special error or value indicating to skip
-	}
 
 	measureValue.Name = aws.String(tagName)
 
@@ -275,51 +271,71 @@ func validateRequiredFields(v any) (reflect.Value, error) {
 		return reflect.Value{}, fmt.Errorf("input is not a struct")
 	}
 
-	requiredTags := map[requiredField]int{
-		measure:   0,
-		timestamp: 0,
-		dimension: 0,
-		attribute: 0,
-	}
-
-	err := validateTypes(val, requiredTags)
+	err := validateTypes(val)
 	if err != nil {
 		return reflect.Value{}, err
 	}
-
-	err = validateAppearances(requiredTags)
+	err = validateAppearances(val)
 	if err != nil {
 		return reflect.Value{}, err
 	}
 	return val, nil
 }
 
-func validateAppearances(requiredTags map[requiredField]int) error {
+func validateAppearances(val reflect.Value) error {
+	requiredTags := map[requiredField]int{
+		measure:   0,
+		timestamp: 0,
+		dimension: 0,
+		attribute: 0,
+	}
+	namesFrequency := make(map[string]int)
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Type().Field(i)
+		tag, ok := field.Tag.Lookup("timestream")
+		if !ok {
+			continue
+		}
+		tagParts := strings.Split(tag, ",")
+		requiredTags[requiredField(tagParts[0])]++
+		tagName, _ := extractTagName(field, tagParts)
+		_, ok = namesFrequency[tagName]
+		if !ok {
+			namesFrequency[tagName] = 1
+		} else {
+			namesFrequency[tagName]++
+		}
+	}
 	for tag, count := range requiredTags {
 		if count == 0 {
 			return fmt.Errorf("missing required tag: %s", tag)
 		}
 		// Assuming multiple dimensions and measureValues are allowed
-		if count > 1 && tag != dimension && tag != attribute {
-			return fmt.Errorf("tag %s appears more than once", tag)
+		if count > 1 && (tag == measure || tag == timestamp) {
+			return fmt.Errorf("tag type %s appears more than once", tag)
+		}
+	}
+	for tn, count := range namesFrequency {
+		if count > 1 {
+			return fmt.Errorf("tag name %s appears multiple times", tn)
 		}
 	}
 	return nil
 }
 
-func validateTypes(val reflect.Value, requiredTags map[requiredField]int) error {
+func validateTypes(val reflect.Value) error {
 	for i := 0; i < val.NumField(); i++ {
 		field := val.Field(i)
 		fieldType := val.Type().Field(i)
 
-		if err := validateField(field, fieldType, requiredTags); err != nil {
+		if err := validateField(field, fieldType); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateField(field reflect.Value, fieldType reflect.StructField, requiredTags map[requiredField]int) error {
+func validateField(field reflect.Value, fieldType reflect.StructField) error {
 	tag, ok := fieldType.Tag.Lookup("timestream")
 	if !ok {
 		return nil
@@ -329,8 +345,6 @@ func validateField(field reflect.Value, fieldType reflect.StructField, requiredT
 	if err := checkOmitEmpty(fieldType, tagParts); err != nil {
 		return err
 	}
-
-	requiredTags[requiredField(strings.Split(tag, ",")[0])]++
 
 	if err := checkFieldAccessibility(field, fieldType); err != nil {
 		return err

--- a/pkg/marshal_test.go
+++ b/pkg/marshal_test.go
@@ -151,6 +151,16 @@ func TestMarshalUnhappyPath(t *testing.T) {
 			}{MeasureName: "measure_name", Dimension: "dimension_name", MeasureValue: "measure_value"},
 		},
 		{
+			name: "Returns err if using bad units",
+			args: struct {
+				Timestamp    time.Time `timestream:"timestamp"`
+				MeasureName  string    `timestream:"measureName"`
+				Dimension    string    `timestream:"dimension"`
+				MeasureValue string    `timestream:"attribute"`
+				BadTime      time.Time `timestream:"badTime",unit=bad-unit`
+			}{Timestamp: now, MeasureName: "measure_name", Dimension: "dimension_name", MeasureValue: "measure_value", BadTime: now},
+		},
+		{
 			name: "Returns err if omitempty on non-string",
 			args: struct {
 				Timestamp    time.Time `timestream:"timestamp"`
@@ -158,6 +168,16 @@ func TestMarshalUnhappyPath(t *testing.T) {
 				Dimension    string    `timestream:"dimension"`
 				MeasureValue float64   `timestream:"attribute,name=SomeName,omitempty"`
 			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now},
+		},
+		{
+			name: "Returns err if repeated tags",
+			args: struct {
+				Timestamp     time.Time `timestream:"timestamp"`
+				MeasureName   string    `timestream:"measureName"`
+				Dimension     string    `timestream:"dimension"`
+				MeasureValue  string    `timestream:"attribute,name=SomeName"`
+				MeasureValue2 string    `timestream:"attribute,name=SomeName"`
+			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now, MeasureValue: "foo", MeasureValue2: "bar"},
 		},
 		{
 			name: "Returns err if timestamp is not time.Time",

--- a/pkg/marshal_test.go
+++ b/pkg/marshal_test.go
@@ -127,7 +127,6 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestMarshalUnhappyPath(t *testing.T) {
-
 	tests := []struct {
 		name string
 		args any
@@ -155,7 +154,7 @@ func TestMarshalUnhappyPath(t *testing.T) {
 			name: "Returns err if using bad units",
 			args: struct {
 				Timestamp    time.Time `timestream:"timestamp"`
-				MeasureName  string    `timestream:"measureName"`
+				MeasureName  string    `timestream:"measure"`
 				Dimension    string    `timestream:"dimension"`
 				MeasureValue string    `timestream:"attribute"`
 				BadTime      time.Time `timestream:"attribute,name=badTime,unit=bad-unit"`
@@ -165,7 +164,7 @@ func TestMarshalUnhappyPath(t *testing.T) {
 			name: "Returns err if omitempty on non-string",
 			args: struct {
 				Timestamp    time.Time `timestream:"timestamp"`
-				MeasureName  string    `timestream:"measureName"`
+				MeasureName  string    `timestream:"measure"`
 				Dimension    string    `timestream:"dimension"`
 				MeasureValue float64   `timestream:"attribute,name=SomeName,omitempty"`
 			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now},
@@ -174,7 +173,7 @@ func TestMarshalUnhappyPath(t *testing.T) {
 			name: "Returns err if repeated tags",
 			args: struct {
 				Timestamp     time.Time `timestream:"timestamp"`
-				MeasureName   string    `timestream:"measureName"`
+				MeasureName   string    `timestream:"measure"`
 				Dimension     string    `timestream:"dimension"`
 				MeasureValue  string    `timestream:"attribute,name=SomeName"`
 				MeasureValue2 string    `timestream:"attribute,name=SomeName"`
@@ -184,12 +183,12 @@ func TestMarshalUnhappyPath(t *testing.T) {
 			name: "Returns err if using a struct other than time",
 			args: struct {
 				Timestamp              time.Time `timestream:"timestamp"`
-				MeasureName            string    `timestream:"measureName"`
+				MeasureName            string    `timestream:"measure"`
 				Dimension              string    `timestream:"dimension"`
 				UnsupportedStructField struct {
 					SomeField string
 				} `timestream:"attribute,name=SomeName"`
-			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now, UnsupportedStructField: struct{SomeField string}{SomeField: "field"}},
+			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now, UnsupportedStructField: struct{ SomeField string }{SomeField: "field"}},
 		},
 		{
 			name: "Returns err if timestamp is not time.Time",

--- a/pkg/marshal_test.go
+++ b/pkg/marshal_test.go
@@ -127,6 +127,7 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestMarshalUnhappyPath(t *testing.T) {
+
 	tests := []struct {
 		name string
 		args any
@@ -157,7 +158,7 @@ func TestMarshalUnhappyPath(t *testing.T) {
 				MeasureName  string    `timestream:"measureName"`
 				Dimension    string    `timestream:"dimension"`
 				MeasureValue string    `timestream:"attribute"`
-				BadTime      time.Time `timestream:"badTime",unit=bad-unit`
+				BadTime      time.Time `timestream:"attribute,name=badTime,unit=bad-unit"`
 			}{Timestamp: now, MeasureName: "measure_name", Dimension: "dimension_name", MeasureValue: "measure_value", BadTime: now},
 		},
 		{
@@ -178,6 +179,17 @@ func TestMarshalUnhappyPath(t *testing.T) {
 				MeasureValue  string    `timestream:"attribute,name=SomeName"`
 				MeasureValue2 string    `timestream:"attribute,name=SomeName"`
 			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now, MeasureValue: "foo", MeasureValue2: "bar"},
+		},
+		{
+			name: "Returns err if using a struct other than time",
+			args: struct {
+				Timestamp              time.Time `timestream:"timestamp"`
+				MeasureName            string    `timestream:"measureName"`
+				Dimension              string    `timestream:"dimension"`
+				UnsupportedStructField struct {
+					SomeField string
+				} `timestream:"attribute,name=SomeName"`
+			}{MeasureName: "measure_name", Dimension: "dimension_name", Timestamp: now, UnsupportedStructField: struct{SomeField string}{SomeField: "field"}},
 		},
 		{
 			name: "Returns err if timestamp is not time.Time",

--- a/pkg/marshal_test.go
+++ b/pkg/marshal_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	now                  = time.Now()
-	arrivalTime          = now.Add(1 * time.Second)
-	formattedNow         = fmt.Sprintf("%d", now.UnixMilli())
-	formattedArrivalTime = fmt.Sprintf("%d", arrivalTime.Unix())
+	now          = time.Now()
+	arrivalTime  = now.Add(1 * time.Second)
+	formattedNow = fmt.Sprintf("%d", now.UnixMilli())
 )
 
 func TestMarshal(t *testing.T) {
@@ -38,6 +37,9 @@ func TestMarshal(t *testing.T) {
 				MeasureValueInt    int       `timestream:"attribute,name=measureValueInt"`
 				EmptyString        string    `timestream:"attribute,name=emptyString"`
 				ArrivalTime        time.Time `timestream:"attribute,name=arrivalTime"`
+				ArrivalTimeMS      time.Time `timestream:"attribute,name=arrivalTimeMs,unit=ms"`
+				ArrivalTimeNS      time.Time `timestream:"attribute,name=arrivalTimeNs,unit=ns"`
+				ArrivalTimeS       time.Time `timestream:"attribute,name=arrivalTimeS,unit=s"`
 				OmitEmpty          string    `timestream:"attribute,name=omitEmptyColumn,omitempty"`
 				IgnorableString    string
 			}{
@@ -49,6 +51,9 @@ func TestMarshal(t *testing.T) {
 				MeasureValueFloat:  123.00,
 				MeasureValueInt:    123,
 				ArrivalTime:        arrivalTime,
+				ArrivalTimeMS:      arrivalTime,
+				ArrivalTimeNS:      arrivalTime,
+				ArrivalTimeS:       arrivalTime,
 			},
 			want: []types.Record{{
 				Time: &formattedNow,
@@ -61,7 +66,10 @@ func TestMarshal(t *testing.T) {
 					{Name: aws.String("measureValueFloat"), Value: aws.String("123.000000"), Type: types.MeasureValueTypeDouble},
 					{Name: aws.String("measureValueInt"), Value: aws.String("123"), Type: types.MeasureValueTypeBigint},
 					{Name: aws.String("emptyString"), Value: aws.String("-"), Type: types.MeasureValueTypeVarchar},
-					{Name: aws.String("arrivalTime"), Value: aws.String(formattedArrivalTime), Type: types.MeasureValueTypeTimestamp},
+					{Name: aws.String("arrivalTime"), Value: aws.String(fmt.Sprintf("%d", arrivalTime.Unix())), Type: types.MeasureValueTypeTimestamp},
+					{Name: aws.String("arrivalTimeMs"), Value: aws.String(fmt.Sprintf("%d", arrivalTime.UnixMilli())), Type: types.MeasureValueTypeTimestamp},
+					{Name: aws.String("arrivalTimeNs"), Value: aws.String(fmt.Sprintf("%d", arrivalTime.UnixNano())), Type: types.MeasureValueTypeTimestamp},
+					{Name: aws.String("arrivalTimeS"), Value: aws.String(fmt.Sprintf("%d", arrivalTime.Unix())), Type: types.MeasureValueTypeTimestamp},
 				},
 				MeasureName: aws.String("measure_name"),
 			}},

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -2,11 +2,12 @@ package timestream
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite/types"
-	"math/rand"
-	"time"
 )
 
 // Schema represents a mapping from table names to measure names and then to
@@ -14,12 +15,14 @@ import (
 // type, allowing for flexibility in defining metric names.
 type Schema[T1 comparable, T2 comparable] map[Table]map[MeasureName]Record[T1, T2]
 
-type Table string
-type MeasureName string
-type Record[T1 comparable, T2 comparable] struct {
-	Dimensions  []T1
-	MetricNames []T2
-}
+type (
+	Table                                string
+	MeasureName                          string
+	Record[T1 comparable, T2 comparable] struct {
+		Dimensions  []T1
+		MetricNames []T2
+	}
+)
 
 type invertedSchema[T comparable] map[T]struct {
 	measureName string
@@ -38,11 +41,11 @@ type TSSchema[T1 comparable, T2 comparable] struct {
 // NewTSSchema initialises a new TSSchema instance from the given Schema.
 // The schema parameter is a mapping from table names to measure names and
 // then to metric names of the generic type T.
-func NewTSSchema[T1 comparable, T2 comparable](schema Schema[T1, T2]) TSSchema[T1, T2] {
+func NewTSSchema[T1, T2 comparable](schema Schema[T1, T2]) TSSchema[T1, T2] {
 	return TSSchema[T1, T2]{Schema: schema, invertedSchema: invertSchema[T1, T2](schema)}
 }
 
-func invertSchema[T1 comparable, T2 comparable](schema Schema[T1, T2]) invertedSchema[T2] {
+func invertSchema[T1, T2 comparable](schema Schema[T1, T2]) invertedSchema[T2] {
 	inverted := make(invertedSchema[T2])
 
 	for tableName, measures := range schema {

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -2,21 +2,24 @@ package timestream_test
 
 import (
 	"fmt"
+	"sort"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"sort"
-	"testing"
-	"time"
 
 	timestream "github.com/EvergenEnergy/TimeSchema/pkg"
 	"github.com/stretchr/testify/assert"
 )
 
-type testMetricName string
-type testDimension string
+type (
+	testMetricName string
+	testDimension  string
+)
 
 func TestTSSchema_GetMeasureNameFor(t *testing.T) {
 	type args struct {
@@ -30,9 +33,11 @@ func TestTSSchema_GetMeasureNameFor(t *testing.T) {
 	}{
 		{
 			name: "Test gets correct measure name",
-			schema: timestream.Schema[string, string]{"table": {"measure": {
-				Dimensions:  []string{},
-				MetricNames: []string{"metric"}},
+			schema: timestream.Schema[string, string]{"table": {
+				"measure": {
+					Dimensions:  []string{},
+					MetricNames: []string{"metric"},
+				},
 			}},
 			args: args{
 				metricName: "metric",
@@ -44,9 +49,11 @@ func TestTSSchema_GetMeasureNameFor(t *testing.T) {
 			schema: timestream.Schema[string, string]{
 				"table": {"measure": {
 					Dimensions:  []string{},
-					MetricNames: []string{"metric"}}},
+					MetricNames: []string{"metric"},
+				}},
 				"table2": {"measure2": {
-					MetricNames: []string{"metric2"}}},
+					MetricNames: []string{"metric2"},
+				}},
 			},
 			args: args{
 				metricName: "metric",


### PR DESCRIPTION
### What?
Add support to express on what units we want to get back the timestamp string when Marshalling

## Why?
This is needed, because we can define different precision in TS and the current solution only assumes seconds.